### PR TITLE
feat(sort): añadir Merge Sort estable y opción 'speciality-group'

### DIFF
--- a/admin/src/composables/useSort.vue.js
+++ b/admin/src/composables/useSort.vue.js
@@ -1,0 +1,170 @@
+import { ref, computed } from 'vue'
+
+/**
+ * Los cuatro criterios de ordenamiento.
+
+ * 'speciality-group' difiere del filtro de botones existente en el admin:
+ *   - El filtro OCULTA doctores de otras especialidades.
+ *   - 'speciality-group' MUESTRA todos los doctores pero los agrupa
+ *     por especialidad consecutivamente.
+ */
+export const SORT_OPTIONS = [
+    { value: 'none', label: 'Default' },
+    { value: 'name-asc', label: 'Name (A → Z)' },
+    { value: 'name-desc', label: 'Name (Z → A)' },
+    { value: 'fees-asc', label: 'Price (low → high)' },
+    { value: 'fees-desc', label: 'Price (high → low)' },
+    { value: 'speciality-group-asc', label: 'Speciality (A → Z, grouped)' },
+    { value: 'speciality-group-desc', label: 'Speciality (Z → A, grouped)' },
+]
+
+/**
+ * Extrae el valor de comparación de un doctor según la clave.
+ * Normaliza null/undefined a '' o 0.
+ *
+ * @param {object} doctor
+ * @param {string} key
+ * @returns {string|number}
+ */
+function getValue(doctor, key) {
+    switch (key) {
+        case 'name':
+            return (doctor.name ?? '').toLowerCase()
+        case 'fees':
+            return typeof doctor.fees === 'number' ? doctor.fees : 0
+        case 'speciality':
+        case 'speciality-group':
+            return (doctor.speciality ?? '').toLowerCase()
+        default:
+            return ''
+    }
+}
+
+// Comparador genérico. Retorna negativo, 0 o positivo.
+function compare(a, b, key, order) {
+    const va = getValue(a, key)
+    const vb = getValue(b, key)
+
+    let result
+    if (typeof va === 'number' && typeof vb === 'number') {
+        result = va - vb
+    } else {
+        result = String(va).localeCompare(String(vb))
+    }
+
+    return order === 'asc' ? result : -result
+}
+
+// Paso de fusión — O(n). El <= preserva la estabilidad.
+function merge(left, right, key, order) {
+    const result = []
+    let i = 0
+    let j = 0
+
+    while (i < left.length && j < right.length) {
+        if (compare(left[i], right[j], key, order) <= 0) {
+            result.push(left[i++])
+        } else {
+            result.push(right[j++])
+        }
+    }
+
+    while (i < left.length) result.push(left[i++])
+    while (j < right.length) result.push(right[j++])
+
+    return result
+}
+
+/**
+ * Merge Sort recursivo — O(n log n), estable.
+ * No muta el arreglo original.
+
+ * @param {Array}  array
+ * @param {string} key
+ * @param {'asc'|'desc'} order
+ * @returns {Array}
+ */
+function mergeSort(array, key, order) {
+    if (array.length <= 1) return array
+
+    const mid = Math.floor(array.length / 2)
+    const left = mergeSort(array.slice(0, mid), key, order)
+    const right = mergeSort(array.slice(mid), key, order)
+
+    return merge(left, right, key, order)
+}
+
+/**
+ * Ordenamiento especial por grupo de especialidad.
+
+ * Ordena las especialidades únicas (A→Z o Z→A) y concatena los
+ * doctores de cada grupo preservando su orden relativo.
+ * TODOS los doctores permanecen visibles — ninguno se filtra.
+
+ * @param {Array}        doctors
+ * @param {'asc'|'desc'} order
+ * @returns {Array}
+ */
+function sortBySpecialityGroup(doctors, order) {
+    if (doctors.length <= 1) return doctors
+
+    const unique = [...new Set(doctors.map((d) => (d.speciality ?? '').toLowerCase()))]
+
+    const sortedSpecs = mergeSort(
+        unique.map((s) => ({ speciality: s })),
+        'speciality',
+        order,
+    ).map((item) => item.speciality)
+
+    const groups = new Map()
+    for (const spec of sortedSpecs) {
+        groups.set(spec, [])
+    }
+    for (const doctor of doctors) {
+        const key = (doctor.speciality ?? '').toLowerCase()
+        groups.get(key)?.push(doctor)
+    }
+
+    return sortedSpecs.flatMap((spec) => groups.get(spec) ?? [])
+}
+/**
+ * useSort — aplica Merge Sort sobre una lista reactiva de doctores.
+ *
+ * Diseñado para integrarse con el filtro de especialidad existente:
+ * recibe `filteredDoctors` (ya filtrada o completa) como Ref o valor plano,
+ * y devuelve `sortedDoctors` como propiedad computada que Vue cachea
+ * automáticamente.
+ *
+ * @param {import('vue').Ref<Array>|Array} filteredDoctors  Lista de doctores.
+ * @returns {{ sortedDoctors, sortOption, SORT_OPTIONS }}
+ *
+ */
+export function useSort(filteredDoctors) {
+    // Opción actualmente seleccionada en la UI
+    const sortOption = ref('none')
+
+    /**
+     * Lista de doctores ordenada.
+     * Vue recalcula este computed solo cuando cambian
+     * `filteredDoctors` o `sortOption` — O(n log n) amortizado.
+     */
+    const sortedDoctors = computed(() => {
+        const list = Array.isArray(filteredDoctors)
+            ? filteredDoctors
+            : filteredDoctors.value ?? []
+
+        if (!list.length || sortOption.value === 'none') return list
+
+        const lastDash = sortOption.value.lastIndexOf('-')
+        const key = sortOption.value.slice(0, lastDash)
+        const order = sortOption.value.slice(lastDash + 1)
+
+        if (key === 'speciality-group') {
+            return sortBySpecialityGroup(list, order)
+        }
+
+        return mergeSort(list, key, order)
+    })
+
+    return { sortedDoctors, sortOption, SORT_OPTIONS }
+}

--- a/admin/src/pages/Admin/DoctorsList.vue
+++ b/admin/src/pages/Admin/DoctorsList.vue
@@ -1,8 +1,24 @@
 <script setup>
-import { onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useAdminContext } from '../../context/AdminContext'
+import { useSort } from '../../composables/useSort.vue'
 
 const { doctors, aToken, getAllDoctors, changeAvailability } = useAdminContext()
+const selectedSpeciality = ref('')
+
+const filteredDoctors = computed(() => {
+    if (!selectedSpeciality.value) return doctors.value
+    return doctors.value.filter(
+        (d) => d.speciality === selectedSpeciality.value,
+    )
+})
+
+const specialities = computed(() => {
+    const unique = [...new Set(doctors.value.map((d) => d.speciality).filter(Boolean))]
+    return unique.sort((a, b) => a.localeCompare(b))
+})
+
+const { sortedDoctors, sortOption, SORT_OPTIONS } = useSort(filteredDoctors)
 
 onMounted(() => {
     if (aToken.value) {
@@ -13,9 +29,35 @@ onMounted(() => {
 
 <template>
     <div class="m-5 max-h-[90vh] overflow-y-scroll w-full">
-        <h1 class="text-lg font-medium">All Doctors</h1>
-        <div class="w-full flex flex-wrap gap-4 pt-5 gap-y-6">
-            <div v-for="(item, index) in doctors" :key="index"
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <h1 class="text-lg font-medium">All Doctors</h1>
+            <div class="flex flex-wrap items-center gap-3">
+                <div class="flex items-center gap-2">
+                    <label class="text-sm text-slate-500 shrink-0">Speciality:</label>
+                    <select v-model="selectedSpeciality"
+                        class="text-sm border border-slate-500 rounded px-3 py-1.5 text-slate-600 bg-indigo-50 focus:outline-none focus:ring-1 focus:ring-indigo-400 cursor-pointer">
+                        <option value="">All</option>
+                        <option v-for="spec in specialities" :key="spec" :value="spec">
+                            {{ spec }}
+                        </option>
+                    </select>
+                </div>
+                <div class="flex items-center gap-2">
+                    <label class="text-sm text-slate-500 shrink-0">Sort by:</label>
+                    <select v-model="sortOption"
+                        class="text-sm border border-slate-500 rounded px-3 py-1.5 text-slate-600 bg-indigo-50 focus:outline-none focus:ring-1 focus:ring-indigo-400 cursor-pointer">
+                        <option v-for="opt in SORT_OPTIONS" :key="opt.value" :value="opt.value">
+                            {{ opt.label }}
+                        </option>
+                    </select>
+                </div>
+                <span class="text-xs text-slate-400">
+                    {{ sortedDoctors.length }} doctor{{ sortedDoctors.length !== 1 ? 's' : '' }}
+                </span>
+            </div>
+        </div>
+        <div class="w-full flex flex-wrap gap-4 pt-2 gap-y-6">
+            <div v-for="(item, index) in sortedDoctors" :key="item._id ?? index"
                 class="border border-indigo-400 rounded-xl max-w-56 overflow-hidden cursor-pointer group">
                 <img class="bg-indigo-50 group-hover:bg-indigo-200 transition-all duration-500 w-full object-cover"
                     :src="item.image" :alt="item.name" />
@@ -29,8 +71,8 @@ onMounted(() => {
                 </div>
             </div>
         </div>
-        <p v-if="doctors.length === 0" class="text-slate-500 mt-6 text-sm">
-            No doctors registered yet.
+        <p v-if="sortedDoctors.length === 0" class="text-slate-500 mt-6 text-sm">
+            No doctors found.
         </p>
     </div>
 </template>

--- a/backend/src/shared/utils/merge-sort.util.ts
+++ b/backend/src/shared/utils/merge-sort.util.ts
@@ -1,0 +1,165 @@
+/**
+ * Merge Sort — O(n log n) estable.
+ *
+ * Adaptado para ordenar arreglos de objetos por una propiedad dinámica.
+ * Es una función pura: no muta el arreglo original.
+ *
+ * Criterio especial 'speciality-group':
+ *   Ordena todos los doctores agrupándolos por especialidad (alfabético),
+ *   y dentro de cada grupo mantiene el orden de inserción (estabilidad).
+ *   Esto difiere del filtro de especialidad del frontend, que OCULTA
+ *   doctores de otras especialidades — aquí TODOS permanecen visibles.
+ */
+
+export type SortOrder = 'asc' | 'desc';
+
+export type SortKey = 'name' | 'fees' | 'speciality' | 'speciality-group';
+
+// Subconjunto de propiedades que usa el algoritmo de ordenamiento
+export interface SortableDoctor {
+    name?: string | null;
+    fees?: number | null;
+    speciality?: string | null;
+    [key: string]: unknown;
+}
+
+/**
+ * Extrae el valor de comparación del doctor según la clave solicitada.
+ * Devuelve un string en lowercase para comparaciones léxicas consistentes,
+ * o un número para fees.  Valores nulos/undefined se normalizan a '' / 0
+ * para evitar NaN o errores de comparación.
+ */
+function getValue(doctor: SortableDoctor, key: SortKey): string | number {
+    switch (key) {
+        case 'name':
+            return (doctor.name ?? '').toLowerCase();
+
+        case 'fees':
+            return typeof doctor.fees === 'number' ? doctor.fees : 0;
+
+        case 'speciality':
+        case 'speciality-group':
+            return (doctor.speciality ?? '').toLowerCase();
+    }
+}
+
+// Comparador genérico.  Retorna < 0, 0 o > 0 igual que Array#sort.
+function compare(
+    a: SortableDoctor,
+    b: SortableDoctor,
+    key: SortKey,
+    order: SortOrder,
+): number {
+    const va = getValue(a, key);
+    const vb = getValue(b, key);
+
+    let result: number;
+
+    if (typeof va === 'number' && typeof vb === 'number') {
+        result = va - vb;
+    } else {
+        result = String(va).localeCompare(String(vb));
+    }
+
+    return order === 'asc' ? result : -result;
+}
+
+// Paso de fusión (merge).  Combina dos mitades ya ordenadas en un único
+// arreglo ordenado.  O(n) tiempo y espacio auxiliar por nivel.
+function merge<T extends SortableDoctor>(
+    left: T[],
+    right: T[],
+    key: SortKey,
+    order: SortOrder,
+): T[] {
+    const result: T[] = [];
+    let i = 0;
+    let j = 0;
+
+    while (i < left.length && j < right.length) {
+        if (compare(left[i], right[j], key, order) <= 0) {
+            result.push(left[i++]);
+        } else {
+            result.push(right[j++]);
+        }
+    }
+
+    while (i < left.length) result.push(left[i++]);
+    while (j < right.length) result.push(right[j++]);
+
+    return result;
+}
+
+/**
+ * Merge Sort recursivo — función principal.
+ *
+ * @param array  Arreglo de doctores (no se muta).
+ * @param key    Propiedad por la que ordenar.
+ * @param order  'asc' | 'desc'
+ * @returns      Nuevo arreglo ordenado.
+ */
+export function mergeSort<T extends SortableDoctor>(
+    array: T[],
+    key: SortKey,
+    order: SortOrder,
+): T[] {
+    if (array.length <= 1) return array;
+
+    const mid = Math.floor(array.length / 2);
+
+    const left = mergeSort(array.slice(0, mid), key, order);
+    const right = mergeSort(array.slice(mid), key, order);
+
+    return merge(left, right, key, order);
+}
+
+/**
+ * Ordena todos los doctores agrupándolos por especialidad.
+ *
+ * Algoritmo:
+ * 1. Extrae las especialidades únicas y las ordena (Merge Sort, O(e log e)).
+ * 2. Para cada especialidad (en orden), extrae los doctores que pertenecen
+ *    a ella (preservando su orden relativo — estabilidad del merge sort).
+ * 3. Concatena los grupos → resultado final O(n log n + e log e).
+ *
+ * Diferencia clave respecto al filtro del frontend:
+ *   - El filtro OCULTA doctores de otras especialidades.
+ *   - Este ordenamiento MUESTRA todos los doctores, pero separados
+ *     visualmente por grupos de especialidad consecutivos.
+ *
+ * @param doctors  Lista completa de doctores.
+ * @param order    'asc' ordena especialidades A→Z; 'desc' Z→A.
+ */
+export function sortBySpecialityGroup<T extends SortableDoctor>(
+    doctors: T[],
+    order: SortOrder,
+): T[] {
+    if (doctors.length <= 1) return doctors;
+
+    const uniqueSpecialities = [
+        ...new Set(doctors.map((d) => (d.speciality ?? '').toLowerCase())),
+    ];
+
+    const sortedSpecialities = mergeSort(
+        uniqueSpecialities.map((s) => ({ speciality: s })),
+        'speciality',
+        order,
+    ).map((item) => item.speciality as string);
+
+    const groups = new Map<string, T[]>();
+    for (const spec of sortedSpecialities) {
+        groups.set(spec, []);
+    }
+
+    for (const doctor of doctors) {
+        const key = (doctor.speciality ?? '').toLowerCase();
+        groups.get(key)?.push(doctor);
+    }
+
+    const result: T[] = [];
+    for (const spec of sortedSpecialities) {
+        result.push(...(groups.get(spec) ?? []));
+    }
+
+    return result;
+}

--- a/frontend/src/hooks/useSort.js
+++ b/frontend/src/hooks/useSort.js
@@ -1,0 +1,151 @@
+import { useState, useMemo } from 'react'
+
+/**
+ * Los cuatro criterios de ordenamiento.
+ *
+ * 'speciality-group' es diferente al filtro de botones existente:
+ *   - El filtro OCULTA doctores de otras especialidades.
+ *   - 'speciality-group' MUESTRA todos los doctores pero los agrupa
+ *     por especialidad consecutivamente (primero todos los de una
+ *     especialidad, luego los de otra, y así).
+ */
+export const SORT_OPTIONS = [
+    { value: 'none', label: 'Default' },
+    { value: 'name-asc', label: 'Name (A → Z)' },
+    { value: 'name-desc', label: 'Name (Z → A)' },
+    { value: 'fees-asc', label: 'Price (low → high)' },
+    { value: 'fees-desc', label: 'Price (high → low)' },
+    { value: 'speciality-group-asc', label: 'Speciality (A → Z, grouped)' },
+    { value: 'speciality-group-desc', label: 'Speciality (Z → A, grouped)' },
+]
+
+/**
+ * Extrae el valor de comparación de un doctor según la clave.
+ * Normaliza null/undefined a '' o 0 para evitar errores.
+ */
+function getValue(doctor, key) {
+    switch (key) {
+        case 'name':
+            return (doctor.name ?? '').toLowerCase()
+        case 'fees':
+            return typeof doctor.fees === 'number' ? doctor.fees : 0
+        case 'speciality':
+        case 'speciality-group':
+            return (doctor.speciality ?? '').toLowerCase()
+        default:
+            return ''
+    }
+}
+
+// Comparador genérico. Retorna negativo, 0 o positivo.
+function compare(a, b, key, order) {
+    const va = getValue(a, key)
+    const vb = getValue(b, key)
+
+    let result
+    if (typeof va === 'number' && typeof vb === 'number') {
+        result = va - vb
+    } else {
+        result = String(va).localeCompare(String(vb))
+    }
+
+    return order === 'asc' ? result : -result
+}
+
+// Paso de fusión — O(n). El <= preserva la estabilidad.
+function merge(left, right, key, order) {
+    const result = []
+    let i = 0
+    let j = 0
+
+    while (i < left.length && j < right.length) {
+        if (compare(left[i], right[j], key, order) <= 0) {
+            result.push(left[i++])
+        } else {
+            result.push(right[j++])
+        }
+    }
+
+    while (i < left.length) result.push(left[i++])
+    while (j < right.length) result.push(right[j++])
+
+    return result
+}
+
+/**
+ * Merge Sort recursivo — O(n log n), estable.
+ * No muta el arreglo original.
+ */
+function mergeSort(array, key, order) {
+    if (array.length <= 1) return array
+
+    const mid = Math.floor(array.length / 2)
+    const left = mergeSort(array.slice(0, mid), key, order)
+    const right = mergeSort(array.slice(mid), key, order)
+
+    return merge(left, right, key, order)
+}
+
+/**
+ * Ordenamiento especial por grupo de especialidad.
+ *
+ * Ordena las especialidades únicas (A→Z o Z→A) y luego
+ * concatena los doctores de cada grupo preservando su orden relativo.
+ * TODOS los doctores permanecen visibles — ninguno se filtra.
+ */
+function sortBySpecialityGroup(doctors, order) {
+    if (doctors.length <= 1) return doctors
+
+    const unique = [...new Set(doctors.map((d) => (d.speciality ?? '').toLowerCase()))]
+
+    const sortedSpecs = mergeSort(
+        unique.map((s) => ({ speciality: s })),
+        'speciality',
+        order,
+    ).map((item) => item.speciality)
+
+    const groups = new Map()
+    for (const spec of sortedSpecs) {
+        groups.set(spec, [])
+    }
+
+    for (const doctor of doctors) {
+        const key = (doctor.speciality ?? '').toLowerCase()
+        groups.get(key)?.push(doctor)
+    }
+
+    return sortedSpecs.flatMap((spec) => groups.get(spec) ?? [])
+}
+
+/**
+ * useSort — aplica Merge Sort sobre una lista de doctores.
+ *
+ * Integración con el filtro de especialidad existente:
+ *   El ordenamiento se aplica DESPUÉS del filtro, sobre la lista
+ *   `filteredDoctors` que recibe como parámetro.  De este modo:
+ *   - Si el usuario filtra por "Gynecologist", verá solo esos doctores
+ *     ordenados por el criterio elegido.
+ *   - Si no hay filtro activo, el ordenamiento actúa sobre todos los doctores.
+ *
+ * @param {Array}  filteredDoctors  Lista ya filtrada por especialidad (o completa).
+ * @returns {{ sortedDoctors, sortOption, setSortOption, SORT_OPTIONS }}
+ */
+export function useSort(filteredDoctors) {
+    const [sortOption, setSortOption] = useState('none')
+
+    const sortedDoctors = useMemo(() => {
+        if (!filteredDoctors?.length) return filteredDoctors ?? []
+
+        if (sortOption === 'none') return filteredDoctors
+
+        const [key, order] = sortOption.split(/-(?=[^-]+$)/) // split en el último '-'
+
+        if (key === 'speciality-group') {
+            return sortBySpecialityGroup(filteredDoctors, order)
+        }
+
+        return mergeSort(filteredDoctors, key, order)
+    }, [filteredDoctors, sortOption])
+
+    return { sortedDoctors, sortOption, setSortOption, SORT_OPTIONS }
+}

--- a/frontend/src/pages/Doctors.jsx
+++ b/frontend/src/pages/Doctors.jsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import { AppContext } from "../context/AppContext"
+import { useSort, SORT_OPTIONS } from "../hooks/useSort"
 
 const Doctors = () => {
 
@@ -9,6 +10,7 @@ const Doctors = () => {
     const [showFilters, setShowFilters] = useState(false)
     const navigate = useNavigate();
     const { doctors } = useContext(AppContext)
+    const { sortedDoctors, sortOption, setSortOption } = useSort(filterDoc)
 
     const applyFilter = () => {
         if (speciality) {
@@ -33,36 +35,95 @@ const Doctors = () => {
                     Filters
                 </button>
                 <div className={`flex-col gap-4 text-sm text-slate-600 ${showFilters ? 'flex' : 'hidden'} sm:flex`}>
-                    <p onClick={() => speciality === 'General physician' ? navigate('/doctors') : navigate('/doctors/General physician')} className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'General physician' ? 'bg-indigo-200 text-slate-950' : ''}`}>General physician</p>
-                    <p onClick={() => speciality === 'Gynecologist' ? navigate('/doctors') : navigate('/doctors/Gynecologist')} className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Gynecologist' ? 'bg-indigo-200 text-slate-950' : ''}`}>Gynecologist</p>
-                    <p onClick={() => speciality === 'Dermatologist' ? navigate('/doctors') : navigate('/doctors/Dermatologist')} className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Dermatologist' ? 'bg-indigo-200 text-slate-950' : ''}`}>Dermatologist</p>
-                    <p onClick={() => speciality === 'Pediatricians' ? navigate('/doctors') : navigate('/doctors/Pediatricians')} className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Pediatricians' ? 'bg-indigo-200 text-slate-950' : ''}`}>Pediatricians</p>
-                    <p onClick={() => speciality === 'Neurologist' ? navigate('/doctors') : navigate('/doctors/Neurologist')} className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Neurologist' ? 'bg-indigo-200 text-slate-950' : ''}`}>Neurologist</p>
-                    <p onClick={() => speciality === 'Gastroenterologist' ? navigate('/doctors') : navigate('/doctors/Gastroenterologist')} className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Gastroenterologist' ? 'bg-indigo-200 text-slate-950' : ''}`}>Gastroenterologist</p>
+                    <p
+                        onClick={() => speciality === 'General physician' ? navigate('/doctors') : navigate('/doctors/General physician')}
+                        className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'General physician' ? 'bg-indigo-200 text-slate-950' : ''}`}
+                    >
+                        General physician
+                    </p>
+                    <p
+                        onClick={() => speciality === 'Gynecologist' ? navigate('/doctors') : navigate('/doctors/Gynecologist')}
+                        className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Gynecologist' ? 'bg-indigo-200 text-slate-950' : ''}`}
+                    >
+                        Gynecologist
+                    </p>
+                    <p
+                        onClick={() => speciality === 'Dermatologist' ? navigate('/doctors') : navigate('/doctors/Dermatologist')}
+                        className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Dermatologist' ? 'bg-indigo-200 text-slate-950' : ''}`}
+                    >
+                        Dermatologist
+                    </p>
+                    <p
+                        onClick={() => speciality === 'Pediatricians' ? navigate('/doctors') : navigate('/doctors/Pediatricians')}
+                        className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Pediatricians' ? 'bg-indigo-200 text-slate-950' : ''}`}
+                    >
+                        Pediatricians
+                    </p>
+                    <p
+                        onClick={() => speciality === 'Neurologist' ? navigate('/doctors') : navigate('/doctors/Neurologist')}
+                        className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Neurologist' ? 'bg-indigo-200 text-slate-950' : ''}`}
+                    >
+                        Neurologist
+                    </p>
+                    <p
+                        onClick={() => speciality === 'Gastroenterologist' ? navigate('/doctors') : navigate('/doctors/Gastroenterologist')}
+                        className={`w-[94vh] sm:w-auto pl-3 py-1.5 pr-16 border border-slate-300 rounded transition-all cursor-pointer ${speciality === 'Gastroenterologist' ? 'bg-indigo-200 text-slate-950' : ''}`}
+                    >
+                        Gastroenterologist
+                    </p>
                 </div>
-                <div className="w-full grid grid-cols-auto gap-4 gap-y-6">
-                    {
-                        filterDoc.map((item, index) => (
+                <div className="w-full flex flex-col gap-4">
+                    <div className="flex items-center gap-2">
+                        <label
+                            htmlFor="sort-select"
+                            className="text-sm text-slate-500 shrink-0"
+                        >
+                            Sort by:
+                        </label>
+                        <select
+                            id="sort-select"
+                            value={sortOption}
+                            onChange={(e) => setSortOption(e.target.value)}
+                            className="text-sm border border-slate-500 rounded px-3 py-1.5 text-slate-600 bg-indigo-50 focus:outline-none focus:ring-1 focus:ring-indigo-400 cursor-pointer"
+                        >
+                            {SORT_OPTIONS.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                    {opt.label}
+                                </option>
+                            ))}
+                        </select>
+                        <span className="text-xs text-slate-400">
+                            {sortedDoctors.length} doctor{sortedDoctors.length !== 1 ? 's' : ''}
+                        </span>
+                    </div>
+                    <div className="w-full grid grid-cols-auto gap-4 gap-y-6">
+                        {sortedDoctors.map((item, index) => (
                             <div
                                 onClick={() => navigate(`/appointment/${item._id}`)}
-                                className='border border-blue-300 rounded-xl overflow-hidden cursor-pointer hover:-translate-y-2.5 transition-all duration-500'
-                                key={index}
+                                className="border border-blue-300 rounded-xl overflow-hidden cursor-pointer hover:-translate-y-2.5 transition-all duration-500"
+                                key={item._id ?? index}
                             >
                                 <img
-                                    className='bg-blue-200'
+                                    className="bg-blue-200 w-full object-cover"
                                     src={item.image}
-                                    alt=""
+                                    alt={item.name}
                                 />
-                                <div className='p-4'>
-                                    <div className={`flex items-center gap-2 text-sm text-center ${item.available ? 'text-green-500' : 'text-gray-500'}`}>
-                                        <p className={`w-2 h-2 ${item.available ? 'bg-green-500' : 'bg-gray-500'} rounded-full`}></p><p>{item.available ? 'Available' : 'Not Available'}</p>
+                                <div className="p-4">
+                                    <div className={`flex items-center gap-2 text-sm ${item.available ? 'text-green-500' : 'text-gray-500'}`}>
+                                        <p className={`w-2 h-2 rounded-full ${item.available ? 'bg-green-500' : 'bg-gray-500'}`} />
+                                        <p>{item.available ? 'Available' : 'Not Available'}</p>
                                     </div>
-                                    <p className='text-slate-900 text-lg font-medium'>{item.name}</p>
-                                    <p className='text-slate-600 text-sm'>{item.speciality}</p>
+                                    <p className="text-slate-900 text-lg font-medium">{item.name}</p>
+                                    <p className="text-slate-600 text-sm">{item.speciality}</p>
                                 </div>
                             </div>
-                        ))
-                    }
+                        ))}
+                    </div>
+                    {sortedDoctors.length === 0 && (
+                        <p className="text-center text-slate-400 py-16 text-sm">
+                            No doctors found for this speciality.
+                        </p>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Resumen por archivo:
- backend/src/shared/utils/merge-sort.util.ts: Implementa un Merge Sort tipado y estable (exporta  y ), normaliza valores nulos y proporciona utilidades reutilizables para ordenar objetos .
- frontend/src/hooks/useSort.js: Añade hook React  con la lógica de Merge Sort y la nueva opción ; expone , ,  y .
- admin/src/composables/useSort.vue.js: Añade composable Vue  (mismo algoritmo) que devuelve ,  y  para el admin.
- frontend/src/pages/Doctors.jsx: Integra  y  en la UI; conecta el select de ordenamiento con  y usa  para renderizar la lista.
- admin/src/pages/Admin/DoctorsList.vue: Integra el composable  en el panel admin; añade select para elegir criterio y muestra  (agrupación por especialidad disponible).