### PR TITLE
feat(admin): añadir exportación de informes (PDF y Excel)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -10,11 +10,14 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.5",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.7",
         "tailwindcss": "^4.2.1",
         "vue": "^3.5.25",
         "vue-i18n": "^11.3.1",
         "vue-router": "^5.0.3",
-        "vue-toastification": "^2.0.0-rc.5"
+        "vue-toastification": "^2.0.0-rc.5",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.2",
@@ -68,6 +71,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1200,6 +1212,26 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.4.tgz",
@@ -1389,6 +1421,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -1438,6 +1479,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -1460,6 +1511,39 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -1473,6 +1557,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/combined-stream": {
@@ -1508,6 +1601,40 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1530,6 +1657,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -1669,6 +1806,17 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1685,6 +1833,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -1720,6 +1874,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1845,6 +2008,26 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -1888,6 +2071,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
       }
     },
     "node_modules/lightningcss": {
@@ -2269,6 +2479,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2280,6 +2496,13 @@
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2360,6 +2583,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -2373,11 +2606,28 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -2447,6 +2697,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -2457,6 +2729,16 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -2476,6 +2758,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -2528,6 +2820,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {
@@ -2713,6 +3015,45 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.2",

--- a/admin/package.json
+++ b/admin/package.json
@@ -11,11 +11,14 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
     "axios": "^1.13.5",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.7",
     "tailwindcss": "^4.2.1",
     "vue": "^3.5.25",
     "vue-i18n": "^11.3.1",
     "vue-router": "^5.0.3",
-    "vue-toastification": "^2.0.0-rc.5"
+    "vue-toastification": "^2.0.0-rc.5",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.2",

--- a/admin/src/components/ReportExportButtons.vue
+++ b/admin/src/components/ReportExportButtons.vue
@@ -1,0 +1,87 @@
+<script setup>
+import { useReportExport } from '../composables/useReportExport.js'
+
+const props = defineProps({
+    rows: { type: Array, default: () => [] },
+    totals: { type: Object, default: () => ({}) },
+    trend: { type: Array, default: () => [] },
+    year: { type: Number, required: true },
+    title: { type: String, default: 'Annual Report' },
+    currency: { type: String, default: '$' },
+    doctor: { type: String, default: null },
+    disabled: { type: Boolean, default: false },
+})
+
+const { exportPDF, exportExcel, exporting } = useReportExport()
+
+const payload = () => ({
+    rows: props.rows,
+    totals: props.totals,
+    trend: props.trend,
+    year: props.year,
+    title: props.title,
+    currency: props.currency,
+    doctor: props.doctor,
+})
+
+const handlePDF = () => exportPDF(payload())
+const handleExcel = () => exportExcel(payload())
+</script>
+
+<template>
+    <div class="flex items-center gap-2">
+        <button @click="handlePDF" :disabled="disabled || exporting"
+            :title="exporting ? 'Generating…' : 'Download PDF report'" class="group relative flex items-center gap-2 px-3.5 py-2 rounded-lg text-sm font-medium
+                    border border-red-200 text-red-600 bg-white
+                    hover:bg-red-50 hover:border-red-400 hover:text-red-700
+                    active:scale-95
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                    transition-all duration-150 shadow-sm cursor-pointer
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400">
+            <svg v-if="exporting" class="w-4 h-4 animate-spin text-red-500" xmlns="http://www.w3.org/2000/svg"
+                fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+
+            <svg v-else class="w-4 h-4 text-red-500 group-hover:text-red-600 transition-colors"
+                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M7 18H17V16H7v2zm10-8H14V6h-4v4H7l5 5 5-5z" />
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                    d="M4 2a2 2 0 00-2 2v16a2 2 0 002 2h16a2 2 0 002-2V8l-6-6H4zm0 2h10v5h5v11H4V4z" />
+            </svg>
+
+            <span>PDF</span>
+
+            <span v-if="exporting"
+                class="absolute -top-1.5 -right-1.5 w-3 h-3 rounded-full bg-red-500 animate-ping opacity-75" />
+        </button>
+
+        <button @click="handleExcel" :disabled="disabled || exporting"
+            :title="exporting ? 'Generating…' : 'Download Excel report'" class="group relative flex items-center gap-2 px-3.5 py-2 rounded-lg text-sm font-medium
+                    border border-green-200 text-green-700 bg-white
+                    hover:bg-green-50 hover:border-green-400 hover:text-green-800
+                    active:scale-95
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                    transition-all duration-150 shadow-sm cursor-pointer
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400">
+            <svg v-if="exporting" class="w-4 h-4 animate-spin text-green-600" xmlns="http://www.w3.org/2000/svg"
+                fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+
+            <svg v-else class="w-4 h-4 text-green-600 group-hover:text-green-700 transition-colors"
+                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                <path
+                    d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM6 20V4h5v7h7v9H6z" />
+                <path d="M8 13h2v2H8zm0 3h2v2H8zm3-3h2v2h-2zm0 3h2v2h-2zm3-3h2v2h-2zm0 3h2v2h-2z" />
+            </svg>
+
+            <span>Excel</span>
+
+            <span v-if="exporting"
+                class="absolute -top-1.5 -right-1.5 w-3 h-3 rounded-full bg-green-500 animate-ping opacity-75" />
+        </button>
+    </div>
+</template>

--- a/admin/src/composables/useReportExport.js
+++ b/admin/src/composables/useReportExport.js
@@ -1,0 +1,316 @@
+import { ref } from 'vue'
+
+export function useReportExport() {
+    const exporting = ref(false)
+
+    function fmt(value, currency = '$') {
+        if (value == null || value === 0) return '—'
+        return `${currency}${Number(value).toLocaleString('en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        })}`
+    }
+
+    function num(value) {
+        return value == null || value === 0 ? '—' : String(value)
+    }
+
+    function nowLabel() {
+        return new Date().toLocaleString('en-US', {
+            year: 'numeric', month: 'short', day: '2-digit',
+            hour: '2-digit', minute: '2-digit',
+        })
+    }
+
+    async function exportPDF({ rows = [], totals = {}, trend = [], year, title = 'Annual Report', currency = '$', doctor = null }) {
+        exporting.value = true
+        try {
+            const { default: jsPDF } = await import('jspdf')
+            const { default: autoTable } = await import('jspdf-autotable')
+
+            const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' })
+
+            const INDIGO     = [99, 102, 241]   // indigo-500  #6366f1
+            const INDIGO_LIGHT = [224, 231, 255] // indigo-100  #e0e7ff
+            const SLATE_700  = [51, 65, 85]
+            const SLATE_500  = [100, 116, 139]
+            const WHITE      = [255, 255, 255]
+            const GREEN      = [22, 163, 74]
+            const RED        = [220, 38, 38]
+
+            const PAGE_W = doc.internal.pageSize.getWidth()
+            const PAGE_H = doc.internal.pageSize.getHeight()
+            let cursorY = 0
+
+            doc.setFillColor(...INDIGO)
+            doc.rect(0, 0, PAGE_W, 22, 'F')
+
+            doc.setTextColor(...WHITE)
+            doc.setFont('helvetica', 'bold')
+            doc.setFontSize(16)
+            doc.text('PRESCRIPTO', 14, 13)
+
+            doc.setFont('helvetica', 'normal')
+            doc.setFontSize(10)
+            const subtitle = doctor ? `${title} — ${doctor}` : title
+            doc.text(subtitle, 14, 19)
+
+            doc.setFontSize(9)
+            doc.text(`${year}  ·  Generated ${nowLabel()}`, PAGE_W - 14, 13, { align: 'right' })
+
+            cursorY = 30
+
+            const kpis = [
+                { label: 'Total Appointments', value: num(totals.totalAppointments) },
+                { label: 'Completed',           value: num(totals.completedAppointments), color: GREEN },
+                { label: 'Cancelled',            value: num(totals.cancelledAppointments), color: RED },
+                { label: 'Total Earnings',       value: fmt(totals.totalEarnings, currency), color: INDIGO },
+            ]
+
+            const cardW = (PAGE_W - 28 - 9) / 4
+            kpis.forEach((kpi, i) => {
+                const x = 14 + i * (cardW + 3)
+                doc.setFillColor(...INDIGO_LIGHT)
+                doc.roundedRect(x, cursorY, cardW, 18, 2, 2, 'F')
+                doc.setTextColor(...SLATE_500)
+                doc.setFontSize(7)
+                doc.setFont('helvetica', 'normal')
+                doc.text(kpi.label.toUpperCase(), x + 4, cursorY + 6)
+                doc.setTextColor(...(kpi.color ?? SLATE_700))
+                doc.setFontSize(12)
+                doc.setFont('helvetica', 'bold')
+                doc.text(kpi.value, x + 4, cursorY + 14)
+            })
+
+            cursorY += 26
+
+            doc.setTextColor(...SLATE_700)
+            doc.setFontSize(10)
+            doc.setFont('helvetica', 'bold')
+            doc.text('Monthly Breakdown', 14, cursorY)
+            cursorY += 4
+
+            const tableRows = rows.map(r => [
+                r.monthLabel,
+                num(r.totalAppointments),
+                num(r.completedAppointments),
+                num(r.cancelledAppointments),
+                fmt(r.earnings, currency),
+                num(r.uniquePatients),
+                fmt(r.cumulativeEarnings, currency),
+            ])
+
+            autoTable(doc, {
+                startY: cursorY,
+                head: [[
+                    'Month', 'Appts', 'Done', 'Cancelled',
+                    'Earnings', 'Patients', 'Cumul. Earnings',
+                ]],
+                body: tableRows,
+                styles: {
+                    fontSize: 8,
+                    cellPadding: { top: 2.5, right: 3, bottom: 2.5, left: 3 },
+                    textColor: SLATE_700,
+                    lineColor: [226, 232, 240],
+                    lineWidth: 0.2,
+                },
+                headStyles: {
+                    fillColor: INDIGO,
+                    textColor: WHITE,
+                    fontStyle: 'bold',
+                    fontSize: 7.5,
+                },
+                alternateRowStyles: { fillColor: [248, 250, 252] },
+                columnStyles: {
+                    0: { fontStyle: 'bold' },
+                    4: { halign: 'right' },
+                    6: { halign: 'right', textColor: INDIGO },
+                },
+                margin: { left: 14, right: 14 },
+            })
+
+            cursorY = doc.lastAutoTable.finalY + 10
+
+            if (trend && trend.length > 0) {
+                const remainingSpace = PAGE_H - cursorY - 20
+                const trendTableH = 10 + trend.length * 7
+
+                if (remainingSpace < trendTableH) {
+                    doc.addPage()
+                    cursorY = 20
+                }
+
+                doc.setTextColor(...SLATE_700)
+                doc.setFontSize(10)
+                doc.setFont('helvetica', 'bold')
+                doc.text('Monthly Trend', 14, cursorY)
+                cursorY += 4
+
+                const trendRows = trend.map(p => [
+                    p.label,
+                    num(p.appointments),
+                    fmt(p.earnings, currency),
+                    `${p.completionRate ?? 0}%`,
+                ])
+
+                autoTable(doc, {
+                    startY: cursorY,
+                    head: [['Period', 'Appointments', 'Earnings', 'Completion Rate']],
+                    body: trendRows,
+                    styles: {
+                        fontSize: 8,
+                        cellPadding: { top: 2.5, right: 4, bottom: 2.5, left: 4 },
+                        textColor: SLATE_700,
+                        lineColor: [226, 232, 240],
+                        lineWidth: 0.2,
+                    },
+                    headStyles: {
+                        fillColor: INDIGO,
+                        textColor: WHITE,
+                        fontStyle: 'bold',
+                        fontSize: 7.5,
+                    },
+                    alternateRowStyles: { fillColor: [248, 250, 252] },
+                    columnStyles: {
+                        2: { halign: 'right' },
+                        3: { halign: 'right' },
+                    },
+                    margin: { left: 14, right: 14 },
+                    tableWidth: 160,
+                })
+            }
+
+            const totalPages = doc.internal.getNumberOfPages()
+            for (let p = 1; p <= totalPages; p++) {
+                doc.setPage(p)
+                doc.setFillColor(...INDIGO)
+                doc.rect(0, PAGE_H - 8, PAGE_W, 8, 'F')
+                doc.setTextColor(...WHITE)
+                doc.setFontSize(7)
+                doc.setFont('helvetica', 'normal')
+                doc.text('Prescripto — Confidential', 14, PAGE_H - 3)
+                doc.text(`Page ${p} of ${totalPages}`, PAGE_W - 14, PAGE_H - 3, { align: 'right' })
+            }
+
+            const safeName = doctor
+                ? `${doctor.replace(/\s+/g, '_')}_report_${year}`
+                : `prescripto_report_${year}`
+            doc.save(`${safeName}.pdf`)
+        } finally {
+            exporting.value = false
+        }
+    }
+
+    async function exportExcel({ rows = [], totals = {}, trend = [], year, title = 'Annual Report', currency = '$', doctor = null }) {
+        exporting.value = true
+        try {
+            const XLSX = await import('xlsx')
+
+            const wb = XLSX.utils.book_new()
+
+            const summaryData = [
+                ['PRESCRIPTO — ' + (doctor ? `${title} (${doctor})` : title)],
+                [`Year: ${year}`, '', `Generated: ${nowLabel()}`],
+                [],
+                ['KPI', 'Value'],
+                ['Total Appointments', totals.totalAppointments ?? 0],
+                ['Completed Appointments', totals.completedAppointments ?? 0],
+                ['Cancelled Appointments', totals.cancelledAppointments ?? 0],
+                ['Total Earnings', totals.totalEarnings ?? 0],
+            ]
+
+            const summarySheet = XLSX.utils.aoa_to_sheet(summaryData)
+            summarySheet['!cols'] = [{ wch: 28 }, { wch: 20 }, { wch: 30 }]
+
+            const earningsCell = summarySheet['B8']
+            if (earningsCell) {
+                earningsCell.t = 'n'
+                earningsCell.z = `"${currency}"#,##0.00`
+            }
+
+            XLSX.utils.book_append_sheet(wb, summarySheet, 'Summary')
+
+            const breakdownHeader = [
+                'Month', 'Total Appointments', 'Completed', 'Cancelled',
+                `Earnings (${currency})`, 'Unique Patients', `Cumulative Earnings (${currency})`,
+            ]
+
+            const breakdownRows = rows.map(r => [
+                r.monthLabel,
+                r.totalAppointments ?? 0,
+                r.completedAppointments ?? 0,
+                r.cancelledAppointments ?? 0,
+                r.earnings ?? 0,
+                r.uniquePatients ?? 0,
+                r.cumulativeEarnings ?? 0,
+            ])
+
+            const totalsRow = [
+                'TOTAL',
+                `=SUM(B2:B13)`,
+                `=SUM(C2:C13)`,
+                `=SUM(D2:D13)`,
+                `=SUM(E2:E13)`,
+                `=MAX(F2:F13)`,
+                rows.length > 0 ? (rows[rows.length - 1].cumulativeEarnings ?? 0) : 0,
+            ]
+
+            const breakdownSheet = XLSX.utils.aoa_to_sheet([
+                breakdownHeader,
+                ...breakdownRows,
+                totalsRow,
+            ])
+
+            breakdownSheet['!cols'] = [
+                { wch: 12 }, { wch: 20 }, { wch: 14 }, { wch: 14 },
+                { wch: 18 }, { wch: 16 }, { wch: 22 },
+            ]
+
+            const range = XLSX.utils.decode_range(breakdownSheet['!ref'] ?? 'A1')
+            for (let row = 1; row <= range.e.r; row++) {
+                ;['E', 'G'].forEach(col => {
+                    const addr = `${col}${row + 1}`
+                    const cell = breakdownSheet[addr]
+                    if (cell && cell.t === 'n') {
+                        cell.z = `"${currency}"#,##0.00`
+                    }
+                })
+            }
+
+            XLSX.utils.book_append_sheet(wb, breakdownSheet, 'Monthly Breakdown')
+
+            if (trend && trend.length > 0) {
+                const trendHeader = ['Period', 'Appointments', `Earnings (${currency})`, 'Completion Rate (%)']
+                const trendRows = trend.map(p => [
+                    p.label,
+                    p.appointments ?? 0,
+                    p.earnings ?? 0,
+                    p.completionRate ?? 0,
+                ])
+
+                const trendSheet = XLSX.utils.aoa_to_sheet([trendHeader, ...trendRows])
+                trendSheet['!cols'] = [{ wch: 18 }, { wch: 16 }, { wch: 18 }, { wch: 20 }]
+
+                const tRange = XLSX.utils.decode_range(trendSheet['!ref'] ?? 'A1')
+                for (let row = 1; row <= tRange.e.r; row++) {
+                    const addr = `C${row + 1}`
+                    const cell = trendSheet[addr]
+                    if (cell && cell.t === 'n') {
+                        cell.z = `"${currency}"#,##0.00`
+                    }
+                }
+
+                XLSX.utils.book_append_sheet(wb, trendSheet, 'Trend')
+            }
+
+            const safeName = doctor
+                ? `${doctor.replace(/\s+/g, '_')}_report_${year}`
+                : `prescripto_report_${year}`
+
+            XLSX.writeFile(wb, `${safeName}.xlsx`)
+        } finally {
+            exporting.value = false
+        }
+    }
+    return { exportPDF, exportExcel, exporting }
+}

--- a/admin/src/pages/Admin/AdminReports.vue
+++ b/admin/src/pages/Admin/AdminReports.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAdminContext } from '../../context/AdminContext'
 import { useAppContext } from '../../context/AppContext'
+import ReportExportButtons from '../../components/ReportExportButtons.vue'
 
 const { aToken, annualReport, monthlyTrend, getAnnualReport, getMonthlyTrend } = useAdminContext()
 const { currency } = useAppContext()
@@ -21,9 +22,9 @@ const reportRows = computed(() => annualReport.value?.report ?? [])
 const totals = computed(() => annualReport.value?.totals ?? {})
 
 const completionRate = computed(() => {
-    const t = totals.value
-    if (!t.totalAppointments) return 0
-    return Math.round((t.completedAppointments / t.totalAppointments) * 100)
+    const tot = totals.value
+    if (!tot.totalAppointments) return 0
+    return Math.round((tot.completedAppointments / tot.totalAppointments) * 100)
 })
 
 const loadData = async () => {
@@ -56,6 +57,9 @@ onMounted(() => {
                 <button @click="loadData" class="text-xs text-indigo-500 hover:underline cursor-pointer">
                     {{ t('adminReports.refresh') }}
                 </button>
+                <ReportExportButtons :rows="reportRows" :totals="totals" :trend="monthlyTrend" :year="selectedYear"
+                    :title="t('adminReports.title')" :currency="currency"
+                    :disabled="loading || reportRows.length === 0" />
             </div>
         </div>
 
@@ -74,8 +78,9 @@ onMounted(() => {
             </div>
             <div class="bg-white rounded-lg border p-4">
                 <p class="text-xs text-slate-400 uppercase">{{ t('adminReports.totalEarnings') }}</p>
-                <p class="text-2xl font-semibold text-indigo-600 mt-1">{{ currency }}{{
-                    totals.totalEarnings?.toLocaleString() }}</p>
+                <p class="text-2xl font-semibold text-indigo-600 mt-1">
+                    {{ currency }}{{ totals.totalEarnings?.toLocaleString() }}
+                </p>
             </div>
         </div>
 

--- a/admin/src/pages/Doctor/DoctorReports.vue
+++ b/admin/src/pages/Doctor/DoctorReports.vue
@@ -3,9 +3,10 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useDoctorContext } from '../../context/DoctorContext'
 import { useAppContext } from '../../context/AppContext'
+import ReportExportButtons from '../../components/ReportExportButtons.vue'
 
 const { t } = useI18n()
-const { dToken, doctorReport, doctorTrend, getDoctorAnnualReport, getDoctorTrend } = useDoctorContext()
+const { dToken, doctorReport, doctorTrend, getDoctorAnnualReport, getDoctorTrend, profileData, getProfileData } = useDoctorContext()
 const { currency } = useAppContext()
 
 const selectedYear = ref(new Date().getFullYear())
@@ -17,6 +18,8 @@ const maxEarnings = computed(() =>
     Math.max(...doctorTrend.value.map(p => p.earnings), 1)
 )
 
+const doctorName = computed(() => profileData.value?.name ?? null)
+
 const loadData = async () => {
     loading.value = true
     await Promise.all([
@@ -26,8 +29,11 @@ const loadData = async () => {
     loading.value = false
 }
 
-onMounted(() => {
-    if (dToken.value) loadData()
+onMounted(async () => {
+    if (dToken.value) {
+        if (!profileData.value?.name) await getProfileData()
+        loadData()
+    }
 })
 </script>
 
@@ -35,9 +41,15 @@ onMounted(() => {
     <div class="m-5 w-full max-w-4xl">
         <div class="flex items-center justify-between mb-5">
             <p class="text-lg font-medium text-gray-700">{{ t('doctorReports.title') }}</p>
-            <select v-model="selectedYear" @change="loadData" class="border rounded px-3 py-1.5 text-sm text-slate-600">
-                <option v-for="y in [2024, 2025, 2026]" :key="y" :value="y">{{ y }}</option>
-            </select>
+            <div class="flex items-center gap-3">
+                <select v-model="selectedYear" @change="loadData"
+                    class="border rounded px-3 py-1.5 text-sm text-slate-600">
+                    <option v-for="y in [2024, 2025, 2026]" :key="y" :value="y">{{ y }}</option>
+                </select>
+                <ReportExportButtons :rows="report" :totals="totals" :trend="doctorTrend" :year="selectedYear"
+                    :title="t('doctorReports.title')" :currency="currency" :doctor="doctorName"
+                    :disabled="loading || report.length === 0" />
+            </div>
         </div>
 
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
@@ -55,8 +67,9 @@ onMounted(() => {
             </div>
             <div class="bg-white rounded-lg border p-4">
                 <p class="text-xs text-slate-400 uppercase">{{ t('doctorReports.earnings') }}</p>
-                <p class="text-xl font-semibold text-slate-700 mt-1">{{ currency }}{{
-                    totals.totalEarnings?.toLocaleString() ?? 0 }}</p>
+                <p class="text-xl font-semibold text-slate-700 mt-1">
+                    {{ currency }}{{ totals.totalEarnings?.toLocaleString() ?? 0 }}
+                </p>
             </div>
         </div>
 


### PR DESCRIPTION
Añade botones y la lógica cliente para exportar los informes desde la interfaz de admin en formatos PDF y Excel. Cambios principales:

Componente: ReportExportButtons.vue:1 : UI reutilizable con botones PDF / Excel, spinner mientras exporta, estado disabled cuando no hay datos o durante la generación y tooltips de estado.
Lógica de exportación: useReportExport.js:1 : implementa exportPDF (jsPDF + jsPDF-AutoTable) y exportExcel (xlsx), helpers de formato (fmt, num, nowLabel), control de estado exporting, nombres de archivo seguros (incluye nombre del doctor si aplica) y formateo de moneda.
Integración en vistas: AdminReports.vue:1 y DoctorReports.vue:1 — incorpora el componente pasando rows, totals, trend, year, title, currency, doctor y deshabilita los botones cuando procede.
Dependencias: package.json:1 — se añadieron jspdf, jspdf-autotable y xlsx para la generación cliente-side de los archivos.
Comportamiento y UX: PDF generado en orientación landscape A4 con KPIs, tabla de desglose mensual y tabla de tendencia; Excel con hojas Summary, Monthly Breakdown y Trend; valores numéricos y moneda formateados; nombre de archivo sanitizado; feedback visual mientras se crea el fichero.